### PR TITLE
Inventory adjustment

### DIFF
--- a/addons/stock/models/stock_inventory.py
+++ b/addons/stock/models/stock_inventory.py
@@ -390,7 +390,7 @@ class InventoryLine(models.Model):
 
             if diff > 0:
                 domain = [('qty', '>', 0.0), ('package_id', '=', line.package_id.id), ('lot_id', '=', line.prod_lot_id.id), ('location_id', '=', line.location_id.id)]
-                preferred_domain_list = [[('reservation_id', '=', False)], [('reservation_id.inventory_id', '!=', line.inventory_id.id)]]
+                preferred_domain_list = [[('reservation_id', '=', False)], [('reservation_id.inventory_id', '!=', line.inventory_id.id)], []]
                 quants = Quant.quants_get_preferred_domain(move.product_qty, move, domain=domain, preferred_domain_list=preferred_domain_list)
                 Quant.quants_reserve(quants, move)
             elif line.package_id:


### PR DESCRIPTION
Description of the issue/feature this PR addresses:
Wrong quant used during inventory adjustment when packages are involved.

Current behavior before PR:
Having 3 packages (pack01, pack02 and pack03) of the same product and lot in the same location, with quantities: 1, 2 and 2.
Inventory adjustment of pack02 from quantity 2 to 1, ends in adjusting the quant of pack01 from 1 to 0 instead.

Desired behavior after PR is merged:
Having 3 packages (pack01, pack02 and pack03) of the same product and lot in the same location, with quantities: 1, 2 and 2.
Inventory adjustment of pack02 from quantity 2 to 1.

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
