### PR TITLE
[IMP] Add front- and back-end timing for RPC calls

### DIFF
--- a/odoo/http.py
+++ b/odoo/http.py
@@ -605,7 +605,7 @@ class JsonRequest(WebRequest):
         self.params = dict(self.jsonrequest.get("params", {}))
         self.context = self.params.pop('context', dict(self.session.context))
 
-    def _json_response(self, result=None, error=None):
+    def _json_response(self, result=None, error=None, duration=None):
         response = {
             'jsonrpc': '2.0',
             'id': self.jsonrequest.get('id')
@@ -626,9 +626,12 @@ class JsonRequest(WebRequest):
             mime = 'application/json'
             body = json.dumps(response)
 
-        return Response(
-                    body, headers=[('Content-Type', mime),
-                                   ('Content-Length', len(body))])
+        headers = [('Content-Type', mime),
+                   ('Content-Length', len(body))]
+        if duration is not None:
+            headers.append(('X-Server-Time', str(duration)))
+
+        return Response(body, headers=headers)
 
     def _handle_exception(self, exception):
         """Called within an except block to allow converting exceptions
@@ -664,7 +667,6 @@ class JsonRequest(WebRequest):
                 method = self.params.get('method')
                 args = self.params.get('args', [])
 
-                start_time = time.time()
                 _, start_vms = 0, 0
                 if psutil:
                     _, start_vms = memory_info(psutil.Process(os.getpid()))
@@ -672,10 +674,11 @@ class JsonRequest(WebRequest):
                     rpc_request.debug('%s: %s %s, %s',
                         endpoint, model, method, pprint.pformat(args))
 
+            start_time = time.time()
             result = self._call_function(**self.params)
+            end_time = time.time()
 
             if rpc_request_flag or rpc_response_flag:
-                end_time = time.time()
                 _, end_vms = 0, 0
                 if psutil:
                     _, end_vms = memory_info(psutil.Process(os.getpid()))
@@ -686,7 +689,7 @@ class JsonRequest(WebRequest):
                 else:
                     rpc_request.debug(logline)
 
-            return self._json_response(result)
+            return self._json_response(result, duration=end_time-start_time)
         except Exception, e:
             return self._handle_exception(e)
 


### PR DESCRIPTION
Description of the issue/feature this PR addresses:
Want to see how the long RPC requests take on front and back end.

Current behaviour before PR:
Request time is only calculated when debug mode enabled, and not included in HTTP headers.
No timing is done on the javascript layer.

Desired behaviour after PR is merged:
Request time is calculated for every request, and is included in custom HTTP header 'X-Server-Time' (when an exception is not raised.)
Javascript layer calculates request time and adds that information to the request complete event.

